### PR TITLE
Pull dev ebirdst

### DIFF
--- a/dockerst/Dockerfile
+++ b/dockerst/Dockerfile
@@ -29,8 +29,7 @@ RUN install.r \
     units uuid \
   && installGithub.r \
     cornelllabofornithology/auk \
-    cornelllabofornithology/ebirdst \
-    tomauer/fastRfuncs
+    cornelllabofornithology/ebirdst@dev_erd2019
 
 WORKDIR /home/docker/
 


### PR DESCRIPTION
dev ebirdst is needed for S&T workflow. Also remove fastRfuncs which is now directly part of ebirdstwf package.